### PR TITLE
Exports parseError to enable external library obtaining location information

### DIFF
--- a/error.go
+++ b/error.go
@@ -38,14 +38,19 @@ func (u UnexpectedTokenError) Message() string { // nolint: golint
 }
 func (u UnexpectedTokenError) Token() lexer.Token { return u.Unexpected } // nolint: golint
 
-type parseError struct {
+// ParseError represents a parsing error in a given location
+type ParseError struct {
 	Msg string
 	Tok lexer.Token
 }
 
-func (p *parseError) Error() string      { return lexer.FormatError(p.Tok.Pos, p.Msg) }
-func (p *parseError) Message() string    { return p.Msg }
-func (p *parseError) Token() lexer.Token { return p.Tok }
+func (p *ParseError) Error() string { return lexer.FormatError(p.Tok.Pos, p.Msg) }
+
+// Message returns the error message
+func (p *ParseError) Message() string { return p.Msg }
+
+// Token returns the token for the error location
+func (p *ParseError) Token() lexer.Token { return p.Tok }
 
 // AnnotateError wraps an existing error with a position.
 //
@@ -54,17 +59,17 @@ func AnnotateError(pos lexer.Position, err error) error {
 	if perr, ok := err.(Error); ok {
 		return perr
 	}
-	return &parseError{Msg: err.Error(), Tok: lexer.Token{Pos: pos}}
+	return &ParseError{Msg: err.Error(), Tok: lexer.Token{Pos: pos}}
 }
 
 // Errorf creats a new Error at the given position.
 func Errorf(pos lexer.Position, format string, args ...interface{}) error {
-	return &parseError{Msg: fmt.Sprintf(format, args...), Tok: lexer.Token{Pos: pos}}
+	return &ParseError{Msg: fmt.Sprintf(format, args...), Tok: lexer.Token{Pos: pos}}
 }
 
 // ErrorWithTokenf creats a new Error with the given token as context.
 func ErrorWithTokenf(tok lexer.Token, format string, args ...interface{}) error {
-	return &parseError{Msg: fmt.Sprintf(format, args...), Tok: tok}
+	return &ParseError{Msg: fmt.Sprintf(format, args...), Tok: tok}
 }
 
 // Wrapf attempts to wrap an existing participle.Error in a new message.

--- a/nodes.go
+++ b/nodes.go
@@ -43,11 +43,11 @@ func decorate(err *error, name func() string) {
 	}
 	switch realError := (*err).(type) {
 	case *lexer.Error:
-		*err = &parseError{Msg: name() + ": " + realError.Msg, Tok: realError.Token()}
-	case *parseError:
-		*err = &parseError{Msg: name() + ": " + realError.Msg, Tok: realError.Token()}
+		*err = &ParseError{Msg: name() + ": " + realError.Msg, Tok: realError.Token()}
+	case *ParseError:
+		*err = &ParseError{Msg: name() + ": " + realError.Msg, Tok: realError.Token()}
 	default:
-		*err = &parseError{Msg: fmt.Sprintf("%s: %s", name(), realError)}
+		*err = &ParseError{Msg: fmt.Sprintf("%s: %s", name(), realError)}
 	}
 }
 


### PR DESCRIPTION
external library cannot cast parseError to participle.Error when unexported